### PR TITLE
SDK: 2.12 version casting problem

### DIFF
--- a/lib/inner_drawer.dart
+++ b/lib/inner_drawer.dart
@@ -434,7 +434,7 @@ class InnerDrawerState extends State<InnerDrawer>
     final Widget scaffoldChild = Stack(
       children: <Widget?>[widget.scaffold, invC != null ? invC : null]
           .where((a) => a != null)
-          .toList() as List<Widget>,
+          .toList().cast<Widget>(),
     );
 
     Widget container = Container(
@@ -617,7 +617,7 @@ class InnerDrawerState extends State<InnerDrawer>
                   ///Trigger
                   _trigger(AlignmentDirectional.centerStart, _leftChild),
                   _trigger(AlignmentDirectional.centerEnd, _rightChild),
-                ].where((a) => a != null).toList() as List<Widget>,
+                ].where((a) => a != null).toList().cast<Widget>(),
               ),
             ),
           ),


### PR DESCRIPTION
Hi guys I'm having this issue because of the new version.

```bash
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following _CastError was thrown building
InnerDrawer-[LabeledGlobalKey<InnerDrawerState>#4b9dd](dirty, dependencies: [_InheritedTheme,
MediaQuery, _EffectiveTickerMode, _LocalizationsScope-[GlobalKey#f63de]], state:
InnerDrawerState#d2fd7(ticker inactive)):
type 'List<Widget?>' is not a subtype of type 'List<Widget>' in type cast
```
The problem is caused because of casting, it's a simple fix and it works... can you guys have a look?