### PR TITLE
fix crash in flutter2; use correct way to filter nullable widgets

### DIFF
--- a/lib/inner_drawer.dart
+++ b/lib/inner_drawer.dart
@@ -5,8 +5,9 @@
 // https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/drawer.dart
 
 import 'dart:math';
-import 'package:flutter/material.dart';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 /// Signature for the callback that's called when a [InnerDrawer] is
@@ -433,8 +434,8 @@ class InnerDrawerState extends State<InnerDrawer>
 
     final Widget scaffoldChild = Stack(
       children: <Widget?>[widget.scaffold, invC != null ? invC : null]
-          .where((a) => a != null)
-          .toList() as List<Widget>,
+          .whereType<Widget>()
+          .toList(),
     );
 
     Widget container = Container(
@@ -617,7 +618,7 @@ class InnerDrawerState extends State<InnerDrawer>
                   ///Trigger
                   _trigger(AlignmentDirectional.centerStart, _leftChild),
                   _trigger(AlignmentDirectional.centerEnd, _rightChild),
-                ].where((a) => a != null).toList() as List<Widget>,
+                ].whereType<Widget>().toList(),
               ),
             ),
           ),


### PR DESCRIPTION
This should close issue #70. the usage of `.where((a) => a != null).toList() as List<Widget>` does not work. with the filter of `where` you still end up with `Widget?` where non of them is null but you can't just cast `List<T?>` to `List<T>` that are not related types. Looks like there is a specific function for that [whereType](https://api.dart.dev/stable/2.10.5/dart-core/Iterable/whereType.html) with a type parameter that can go from `T?`to `T`.   