### PR TITLE
Fix for cast widget list for dart null safety

### DIFF
--- a/lib/inner_drawer.dart
+++ b/lib/inner_drawer.dart
@@ -432,9 +432,11 @@ class InnerDrawerState extends State<InnerDrawer>
     final Widget? invC = _invisibleCover();
 
     final Widget scaffoldChild = Stack(
-      children: <Widget?>[widget.scaffold, invC != null ? invC : null]
-          .where((a) => a != null)
-          .toList() as List<Widget>,
+      children: <Widget>[
+        widget.scaffold,
+        if(invC != null)
+          invC
+      ],
     );
 
     Widget container = Container(
@@ -617,7 +619,7 @@ class InnerDrawerState extends State<InnerDrawer>
                   ///Trigger
                   _trigger(AlignmentDirectional.centerStart, _leftChild),
                   _trigger(AlignmentDirectional.centerEnd, _rightChild),
-                ].where((a) => a != null).toList() as List<Widget>,
+                ].where((a) => a != null).cast<Widget>(),
               ),
             ),
           ),


### PR DESCRIPTION
Fix for error "type 'List<Widget?>' is not a subtype of type 'List<Widget>' in type cast"


════════ (10) Exception caught by scheduler library ════════════════════════════════════════════════
Null check operator used on a null value
════════════════════════════════════════════════════════════════════════════════════════════════════

════════ (11) Exception caught by widgets library ══════════════════════════════════════════════════
type 'List<Widget?>' is not a subtype of type 'List<Widget>' in type cast
The relevant error-causing widget was: 
  InnerDrawer-[LabeledGlobalKey<InnerDrawerState>#9215e]
════════════════════════════════════════════════════════════════════════════════════════════════════