### PR TITLE
Fix type cast using 'whereType' instead of 'as' operator

### DIFF
--- a/lib/inner_drawer.dart
+++ b/lib/inner_drawer.dart
@@ -434,7 +434,8 @@ class InnerDrawerState extends State<InnerDrawer>
     final Widget scaffoldChild = Stack(
       children: <Widget?>[widget.scaffold, invC != null ? invC : null]
           .where((a) => a != null)
-          .toList() as List<Widget>,
+          .whereType<Widget>()
+          .toList(),
     );
 
     Widget container = Container(
@@ -617,7 +618,7 @@ class InnerDrawerState extends State<InnerDrawer>
                   ///Trigger
                   _trigger(AlignmentDirectional.centerStart, _leftChild),
                   _trigger(AlignmentDirectional.centerEnd, _rightChild),
-                ].where((a) => a != null).toList() as List<Widget>,
+                ].where((a) => a != null).whereType<Widget>().toList(),
               ),
             ),
           ),


### PR DESCRIPTION
## Description

This is the minimal fix for typecasting error caused in null safety mode. 

## Implementation: 
### Issue:
```
<Widget?>[....].where((a) => a != null).toList() as List<Widget>

// causes type 'List<Widget?>' is not a subtype of type 'List<Widget>' in type cast
```
### Fix:
```
<Widget?>[....].where((a) => a != null).whereType<Widget>().toList()
```
Effective line numbers: [435-437], [600-620]
## Related Issues
#69 #70 #71 #72 