### PR TITLE
Fix animation behavior with negative horizontal offset to support narrower drawer.

### DIFF
--- a/lib/inner_drawer.dart
+++ b/lib/inner_drawer.dart
@@ -280,16 +280,7 @@ class InnerDrawerState extends State<InnerDrawer>
         ? widget.offset.left
         : widget.offset.right;
 
-    double ee = 1;
-    if (offset <= 0.2)
-      ee = 1.7;
-    else if (offset <= 0.4)
-      ee = 1.2;
-    else if (offset <= 0.6) ee = 1.05;
-
-    offset = 1 -
-        (pow(offset / ee, 1 / 2)
-            as double); //(num.parse(pow(offset/2,1/3).toStringAsFixed(1)));
+    offset = exp(-2.05 * offset) as double;
 
     switch (_position) {
       case InnerDrawerDirection.end:


### PR DESCRIPTION
Currently, `flutter_inner_drawer` supports using a negative horizontal offset. However, doing so breaks the animation when revealing and hiding the drawer, forcing you to use a minimum horizontal offset of `0`.

This change fixes that, allowing drawers that are narrower than half the screen width to be configured. Supporting this is particularly useful for devices in landscape mode like tablets.

The changes to the drift (difference in movement compared to gesture) is almost negligible and is comparable to the drift that already exists.

The value of `2.05` was used when manually tuning as it offered the most similar experience for both positive and negative offsets.