### PR TITLE
Support devices with very narrow widths.

### DIFF
--- a/lib/inner_drawer.dart
+++ b/lib/inner_drawer.dart
@@ -259,7 +259,7 @@ class InnerDrawerState extends State<InnerDrawer>
       if (box != null &&
           box.hasSize &&
           box.size != null &&
-          box.size.width > 300)
+          box.size.width > 250)
         setState(() {
           _initWidth = box.size.width;
         });


### PR DESCRIPTION
Devices like the Samsung Galaxy Fold's outer screens have widths that are smaller than 300.

This allows the drawer to be set to the correct width on these narrow screens rather than being locked to the initial 400 set [here](https://github.com/Dn-a/flutter_inner_drawer/blob/master/lib/inner_drawer.dart#L35).