### PR TITLE
Use MediaQuery width to set drawer width.

### DIFF
--- a/lib/inner_drawer.dart
+++ b/lib/inner_drawer.dart
@@ -252,16 +252,11 @@ class InnerDrawerState extends State<InnerDrawer>
 
   /// get width of screen after initState
   void _updateWidth() {
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
-      final RenderBox? box =
-          _drawerKey.currentContext!.findRenderObject() as RenderBox?;
-      //final RenderBox box = context.findRenderObject();
-      if (box != null &&
-          box.hasSize &&
-          box.size != null &&
-          box.size.width > 300)
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      double width = MediaQuery.of(context).size.width;
+      if (width > 250)
         setState(() {
-          _initWidth = box.size.width;
+          _initWidth = width;
         });
     });
   }


### PR DESCRIPTION
RenderBox width does not take into account the device orientation. This means if the width is updated while in landscape it will be incorrect.