### PR TITLE
flutter-3.22.2-null-safety-and-deprecated-theme-background-fix

### DIFF
--- a/lib/inner_drawer.dart
+++ b/lib/inner_drawer.dart
@@ -434,7 +434,7 @@ class InnerDrawerState extends State<InnerDrawer>
     final Widget scaffoldChild = Stack(
       children: <Widget?>[widget.scaffold, invC != null ? invC : null]
           .where((a) => a != null)
-          .toList() as List<Widget>,
+          .toList().cast<Widget>(),
     );
 
     Widget container = Container(
@@ -582,7 +582,7 @@ class InnerDrawerState extends State<InnerDrawer>
     return Container(
       decoration: widget.backgroundDecoration ??
           BoxDecoration(
-            color: Theme.of(context).backgroundColor,
+            color: Theme.of(context).colorScheme.background,
           ),
       child: Stack(
         alignment: _drawerInnerAlignment!,
@@ -617,7 +617,7 @@ class InnerDrawerState extends State<InnerDrawer>
                   ///Trigger
                   _trigger(AlignmentDirectional.centerStart, _leftChild),
                   _trigger(AlignmentDirectional.centerEnd, _rightChild),
-                ].where((a) => a != null).toList() as List<Widget>,
+                ].where((a) => a != null).toList().cast<Widget>(),
               ),
             ),
           ),


### PR DESCRIPTION
This fork combines the fixes from the following pull requests:

kenjishiromajp:kenjishiromajp-update-for-2.12-null-safety-casting: Dn-a#69

Smibser:fix-deprectaed-theme-backgroundColor:
Dn-a#82